### PR TITLE
Add documentation about alarm setup

### DIFF
--- a/deployment/setup.md
+++ b/deployment/setup.md
@@ -293,7 +293,7 @@ To create the alarm, link it to the defined metric and namespace and provide the
 aws cloudwatch put-metric-alarm --alarm-name vespawatch-internal-server-error --alarm-description "Alarm on Internal server errors of vespawatch website"  --metric-name vespawatch_internal_server_error_count  --namespace vespawatch_logs  --statistic Sum  --period 300  --threshold 0 --comparison-operator GreaterThanThreshold --evaluation-periods 1 --alarm-actions arn:aws:sns:eu-west-1:226308051916:lw-vespawatch-alerts --treat-missing-data notBreaching
 ```
 
-See also: https://docs.aws.amazon.com/cli/latest/reference/cloudwatch/put-metric-alarm.html and https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/AlarmThatSendsEmail.html
+See also: https://docs.aws.amazon.com/cli/latest/reference/cloudwatch/put-metric-alarm.html and https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/AlarmThatSendsEmail.html do not use the `--unit Count` option with this kind of setup (although it seems logical), as this will not result in proper switch to ALARM.
 
 
 ## Backups

--- a/deployment/setup.md
+++ b/deployment/setup.md
@@ -290,10 +290,10 @@ Note: `metricValue=1` is the count increase when an occurrence is detected
 To create the alarm, link it to the defined metric and namespace and provide the SNS topic as `alarm-action`:
 
 ```
-aws cloudwatch put-metric-alarm --alarm-name vespawatch-internal-server-error --alarm-description "Alarm on Internal server errors of vespawatch website"  --metric-name vespawatch_internal_server_error_count  --namespace vespawatch_logs  --statistic Sum  --period 300  --threshold 1 --comparison-operator GreaterThanOrEqualToThreshold --evaluation-periods 1 --alarm-actions arn:aws:sns:eu-west-1:xxxxxxxx --unit Count
+aws cloudwatch put-metric-alarm --alarm-name vespawatch-internal-server-error --alarm-description "Alarm on Internal server errors of vespawatch website"  --metric-name vespawatch_internal_server_error_count  --namespace vespawatch_logs  --statistic Sum  --period 300  --threshold 0 --comparison-operator GreaterThanThreshold --evaluation-periods 1 --alarm-actions arn:aws:sns:eu-west-1:226308051916:lw-vespawatch-alerts --treat-missing-data notBreaching
 ```
 
-See alo: https://docs.aws.amazon.com/cli/latest/reference/cloudwatch/put-metric-alarm.html
+See also: https://docs.aws.amazon.com/cli/latest/reference/cloudwatch/put-metric-alarm.html and https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/AlarmThatSendsEmail.html
 
 
 ## Backups


### PR DESCRIPTION
PR to explain the addition of cloudwatch alarms on specific error messages. The effective implementation can be adapted by (1) adjusting the error setup provided by django and (2) provide other and/or more rules, but the setup documentation is provided in this PR.