### PR TITLE
Upgrade django=2.1.6, urllib3=1.24.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ boto3==1.9.38
 certifi==2018.8.24
 chardet==3.0.4
 dateparser==0.7.0
-Django==2.1.7
+Django==2.1.8
 django-appconf==1.0.2
 django-crispy-forms==1.7.2
 django-debug-toolbar==1.11

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ boto3==1.9.38
 certifi==2018.8.24
 chardet==3.0.4
 dateparser==0.7.0
-Django==2.1.5
+Django==2.1.7
 django-appconf==1.0.2
 django-crispy-forms==1.7.2
 django-debug-toolbar==1.11
@@ -24,4 +24,4 @@ requests==2.20.0
 six==1.11.0
 sqlparse==0.2.4
 tzlocal==1.5.1
-urllib3==1.23
+urllib3==1.24.2


### PR DESCRIPTION
To address GitHub security alerts:

<img width="746" alt="Screenshot 2019-04-30 at 10 58 35" src="https://user-images.githubusercontent.com/600993/56951016-0a330580-6b37-11e9-8806-16381c2a1771.png">

@niconoe these are updates to new minor versions and everything still seems to work locally, but wanted to give you a chance to review.