### PR TITLE
Inaturalist syncronization cron logs streaming to cloudwatch

### DIFF
--- a/.ebextensions/04_django_logs.config
+++ b/.ebextensions/04_django_logs.config
@@ -64,6 +64,16 @@ files:
       log_stream_name = {instance_id}
       file = /opt/python/log/django.log
 
+  "/etc/awslogs/config/inaturalist-sync-logs.conf" :
+    mode: "000600"
+    owner: root
+    group: root
+    content: |
+      [/var/log/cron_inaturalist_sync.log]
+      log_group_name = `{"Fn::Join":["/", ["/aws/elasticbeanstalk", { "Ref":"AWSEBEnvironmentName" }, "var/log/cron_inaturalist_sync.log"]]}`
+      log_stream_name = {instance_id}
+      file = /var/log/cron_inaturalist_sync.log
+
 commands:
   01_change_log_permissions:  # make sure new files get defined group
     command: chmod g+s /opt/python/log

--- a/deployment/README.md
+++ b/deployment/README.md
@@ -336,6 +336,7 @@ By default, logs are stored forever. This is not required as 3 months of logs wi
 
 ```
 aws logs put-retention-policy --log-group-name /aws/elasticbeanstalk/vespawatch-uat/opt/python/log/django.log --retention-in-days 90
+aws logs put-retention-policy --log-group-name /aws/elasticbeanstalk/vespawatch-uat/var/log/cron_inaturalist_sync.log --retention-in-days 90
 ```
 
 #### Create alarm on filter and publish to SNS


### PR DESCRIPTION
This PR pushes the output of the inaturalist cron job to cloudwatch, which can be used to have a quick overview of the sync status or - if required - link to metrics/alarms to alert the maintainers/developers if required. 

Deployed and tested on UAT with succes.