### PR TITLE
Vue fields styling

### DIFF
--- a/static_src/js/vespawatch.js
+++ b/static_src/js/vespawatch.js
@@ -1082,6 +1082,15 @@ var VwLocationSelectorCoordinates = {
         commontInputClasses: function () {
             return ['numberinput', 'form-control'];
         },
+        addressInputClasses: function() {
+            var cssClasses =  this.commontInputClasses();
+            console.log('address is invalid: ');
+            console.log(this.addressIsInvalid);
+            if (this.addressIsInvalid === true) {
+                cssClasses.push('is-invalid');
+            }
+            return cssClasses.join(' ');
+        },
         latInputClasses: function() {
             var cssClasses =  this.commontInputClasses();
             if (this.latitudeIsInvalid === true) {
@@ -1099,7 +1108,7 @@ var VwLocationSelectorCoordinates = {
 
         }
     },
-    props: ['longitude', 'latitude', 'address', 'addressRequired', 'latitudeIsInvalid', 'longitudeIsInvalid'],
+    props: ['longitude', 'latitude', 'address', 'addressRequired', 'addressIsInvalid', 'latitudeIsInvalid', 'longitudeIsInvalid'],
     template: `
         <div>
             <div class="form-row">
@@ -1118,7 +1127,7 @@ var VwLocationSelectorCoordinates = {
             <div class="form-row">
                 <div class="form-group col-12">
                     <label for="id_address">{{addressLabel}}<span v-if="addressRequired">*</span></label>
-                    <input type="text" class="form-control numberinput" id="id_address" name="address" v-model="_address">
+                    <input type="text" :class="addressInputClasses()" id="id_address" name="address" v-model="_address">
                     <p id="error_1_id_address" class="invalid-feedback"><strong>{{ errorMsg }}</strong></p>
                     <small class="form-text text-muted">{{addressHelpLabel}}</small>
                 </div>
@@ -1252,13 +1261,13 @@ var VwLocationSelector = {
         },
     },
 
-    props: ['initCoordinates', 'initializeCoordinates', 'initMarker', 'address', 'addressRequired', 'latitudeIsInvalid', 'longitudeIsInvalid'],
+    props: ['initCoordinates', 'initializeCoordinates', 'initMarker', 'address', 'addressRequired', 'addressIsInvalid', 'latitudeIsInvalid', 'longitudeIsInvalid'],
 
     template: `
         <div class="row">
             <div class="col-lg-6">
                 <vw-location-selector-location-input v-bind:init-address="address" v-on:autodetect-btn="autodetectPosition" v-on:search="getCoordinates"></vw-location-selector-location-input>
-                <vw-location-selector-coordinates v-bind:longitude="locationLng" v-bind:latitude="locationLat" v-bind:address="modelAddress" v-on:lon-updated="updateLongitude" v-on:lat-updated="updateLatitude" v-bind:address-required="addressRequired" v-bind:latitude-is-invalid="latitudeIsInvalid" v-bind:longitude-is-invalid="longitudeIsInvalid"></vw-location-selector-coordinates>
+                <vw-location-selector-coordinates v-bind:longitude="locationLng" v-bind:latitude="locationLat" v-bind:address="modelAddress" v-on:lon-updated="updateLongitude" v-on:lat-updated="updateLatitude" v-bind:address-required="addressRequired" v-bind:latitude-is-invalid="latitudeIsInvalid" v-bind:longitude-is-invalid="longitudeIsInvalid" v-bind:address-is-invalid="addressIsInvalid"></vw-location-selector-coordinates>
             </div>
             <div class="col-lg-6">
                 <vw-location-selector-map v-bind:init-marker="initMarker" v-bind:position="markerCoordinates" v-on:marker-move="setCoordinates"></vw-location-selector-map>

--- a/static_src/js/vespawatch.js
+++ b/static_src/js/vespawatch.js
@@ -1034,6 +1034,9 @@ var VwLocationSelectorMap = {
 
 var VwLocationSelectorCoordinates = {
     computed: {
+        errorMsg: function () {
+            return gettext('This field is required.')
+        },
         lat: {
             get: function () {
                 return this.latitude
@@ -1103,17 +1106,20 @@ var VwLocationSelectorCoordinates = {
                 <div class="form-group col-6">
                     <label for="id_latitude">{{latitudeLabel}}<span>*</span></label>
                     <input type="text" :class="latInputClasses()" id="id_latitude" name="latitude" v-model="lat">
+                    <p id="error_1_id_latitude" class="invalid-feedback"><strong>{{ errorMsg }}</strong></p>
                     <small class="form-text text-muted">{{coordinatesHelpLabel}}</small>
                 </div>
                 <div class="form-group col-6">
                     <label for="id_longitude">{{longitudeLabel}}<span>*</span></label>
                     <input type="text" :class="lonInputClasses()" id="id_longitude" name="longitude" v-model="long">
+                    <p id="error_1_id_longitude" class="invalid-feedback"><strong>{{ errorMsg }}</strong></p>
                 </div>
             </div>
             <div class="form-row">
                 <div class="form-group col-12">
                     <label for="id_address">{{addressLabel}}<span v-if="addressRequired">*</span></label>
                     <input type="text" class="form-control numberinput" id="id_address" name="address" v-model="_address">
+                    <p id="error_1_id_address" class="invalid-feedback"><strong>{{ errorMsg }}</strong></p>
                     <small class="form-text text-muted">{{addressHelpLabel}}</small>
                 </div>
             </div>
@@ -1147,6 +1153,9 @@ var VwDatetimeSelector = {
         }
     },
     computed: {
+        errorMsg: function () {
+            return gettext('This field is required.')
+        },
         observationTimeLabel: function () {
             return gettext('Observation date');
         },
@@ -1160,7 +1169,9 @@ var VwDatetimeSelector = {
     template: `<div class="form-group">
                     <datetime v-model="observationTime" type="datetime" 
                               :input-class="inputClasses()" :max-datetime="nowIsoFormat()">
-                        <label for="startDate" slot="before">[[ observationTimeLabel ]]<span v-if="isRequired">*</span></label>          
+                        <label for="startDate" slot="before">[[ observationTimeLabel ]]<span v-if="isRequired">*</span></label>
+                    <p slot="after" id="error_1_id_observation_time" class="invalid-feedback"><strong>[[ errorMsg ]]</strong></p>
+          
                     </datetime>
                     <input type="hidden" :name="hiddenFieldName" :value="observationTime"/>
                </div>`

--- a/static_src/js/vespawatch.js
+++ b/static_src/js/vespawatch.js
@@ -1075,18 +1075,39 @@ var VwLocationSelectorCoordinates = {
         }
 
     },
-    props: ['longitude', 'latitude', 'address', 'addressRequired'],
+    methods: {
+        commontInputClasses: function () {
+            return ['numberinput', 'form-control'];
+        },
+        latInputClasses: function() {
+            var cssClasses =  this.commontInputClasses();
+            if (this.latitudeIsInvalid === true) {
+                cssClasses.push('is-invalid');
+            }
+            return cssClasses.join(' ');
+
+        },
+        lonInputClasses: function() {
+            var cssClasses =  this.commontInputClasses();
+            if (this.longitudeIsInvalid) {
+                cssClasses.push('is-invalid');
+            }
+            return cssClasses.join(' ');
+
+        }
+    },
+    props: ['longitude', 'latitude', 'address', 'addressRequired', 'latitudeIsInvalid', 'longitudeIsInvalid'],
     template: `
         <div>
             <div class="form-row">
                 <div class="form-group col-6">
                     <label for="id_latitude">{{latitudeLabel}}<span>*</span></label>
-                    <input type="text" class="form-control numberinput" id="id_latitude" name="latitude" v-model="lat">
+                    <input type="text" :class="latInputClasses()" id="id_latitude" name="latitude" v-model="lat">
                     <small class="form-text text-muted">{{coordinatesHelpLabel}}</small>
                 </div>
                 <div class="form-group col-6">
                     <label for="id_longitude">{{longitudeLabel}}<span>*</span></label>
-                    <input type="text" class="form-control numberinput" id="id_longitude" name="longitude" v-model="long">
+                    <input type="text" :class="lonInputClasses()" id="id_longitude" name="longitude" v-model="long">
                 </div>
             </div>
             <div class="form-row">
@@ -1220,13 +1241,13 @@ var VwLocationSelector = {
         },
     },
 
-    props: ['initCoordinates', 'initializeCoordinates', 'initMarker', 'address', 'addressRequired'],
+    props: ['initCoordinates', 'initializeCoordinates', 'initMarker', 'address', 'addressRequired', 'latitudeIsInvalid', 'longitudeIsInvalid'],
 
     template: `
         <div class="row">
             <div class="col-lg-6">
                 <vw-location-selector-location-input v-bind:init-address="address" v-on:autodetect-btn="autodetectPosition" v-on:search="getCoordinates"></vw-location-selector-location-input>
-                <vw-location-selector-coordinates v-bind:longitude="locationLng" v-bind:latitude="locationLat" v-bind:address="modelAddress" v-on:lon-updated="updateLongitude" v-on:lat-updated="updateLatitude" v-bind:address-required="addressRequired"></vw-location-selector-coordinates>
+                <vw-location-selector-coordinates v-bind:longitude="locationLng" v-bind:latitude="locationLat" v-bind:address="modelAddress" v-on:lon-updated="updateLongitude" v-on:lat-updated="updateLatitude" v-bind:address-required="addressRequired" v-bind:latitude-is-invalid="latitudeIsInvalid" v-bind:longitude-is-invalid="longitudeIsInvalid"></vw-location-selector-coordinates>
             </div>
             <div class="col-lg-6">
                 <vw-location-selector-map v-bind:init-marker="initMarker" v-bind:position="markerCoordinates" v-on:marker-move="setCoordinates"></vw-location-selector-map>

--- a/static_src/js/vespawatch.js
+++ b/static_src/js/vespawatch.js
@@ -1106,6 +1106,7 @@ var VwDatetimeSelector = {
         'initDateTime': String,
         'isRequired': Boolean,
         'hiddenFieldName': String,
+        'validationError': Boolean
     },
     data: function () {
         return {
@@ -1115,6 +1116,13 @@ var VwDatetimeSelector = {
     methods: {
         nowIsoFormat: function () {
             return new Date().toISOString();
+        },
+        inputClasses: function () {
+            var cssClasses =  ['datetimeinput', 'form-control'];
+            if (this.validationError) {
+                cssClasses.push('is-invalid');
+            }
+            return cssClasses.join(' ');
         }
     },
     computed: {
@@ -1130,7 +1138,7 @@ var VwDatetimeSelector = {
     },
     template: `<div class="form-group">
                     <datetime v-model="observationTime" type="datetime" 
-                              input-class="datetimeinput form-control" :max-datetime="nowIsoFormat()">
+                              :input-class="inputClasses()" :max-datetime="nowIsoFormat()">
                         <label for="startDate" slot="before">[[ observationTimeLabel ]]<span v-if="isRequired">*</span></label>          
                     </datetime>
                     <input type="hidden" :name="hiddenFieldName" :value="observationTime"/>

--- a/vespawatch/forms.py
+++ b/vespawatch/forms.py
@@ -9,6 +9,10 @@ class IndividualForm(ModelForm):
     card_id = IntegerField()
     terms_of_service = BooleanField(label=_('Accept the privacy policy'), required=False)
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.date_is_invalid = False
+
     class Meta:
         model = Individual
         fields = ['taxon', 'individual_count', 'behaviour', 'address', 'latitude', 'longitude',
@@ -30,6 +34,10 @@ class IndividualForm(ModelForm):
             msg = 'You must add at least one picture'
             self.add_error(None, msg)
 
+        # For Vue.js components
+        if 'observation_time' in self.errors:
+            self.date_is_invalid = True
+
         return cleaned_data
 
     def save(self, *args, **kwargs):
@@ -41,12 +49,6 @@ class IndividualForm(ModelForm):
 
 class IndividualFormUnauthenticated(IndividualForm):
     observer_email = EmailField(label=_('Email address'))
-
-    def __init__(self, *args, **kwargs):
-        super(IndividualFormUnauthenticated, self).__init__(*args, **kwargs)
-        self.date_is_invalid = False
-
-    # TODO: on validation, sets 'date_is_invalid' in case of error.
 
     class Meta:
         model = Individual

--- a/vespawatch/forms.py
+++ b/vespawatch/forms.py
@@ -19,6 +19,7 @@ class ReportObservationForm(ModelForm):
 
     def clean(self):
         cleaned_data = self.cleaned_data
+        self.errors_as_json = self.errors.as_json()
 
         for vue_field in OBS_FORM_VUE_FIELDS:
             if vue_field['field_name'] in self.errors:

--- a/vespawatch/forms.py
+++ b/vespawatch/forms.py
@@ -42,6 +42,12 @@ class IndividualForm(ModelForm):
 class IndividualFormUnauthenticated(IndividualForm):
     observer_email = EmailField(label=_('Email address'))
 
+    def __init__(self, *args, **kwargs):
+        super(IndividualFormUnauthenticated, self).__init__(*args, **kwargs)
+        self.date_is_invalid = False
+
+    # TODO: on validation, sets 'date_is_invalid' in case of error.
+
     class Meta:
         model = Individual
         fields = ['taxon', 'individual_count', 'behaviour', 'address', 'latitude', 'longitude',

--- a/vespawatch/forms.py
+++ b/vespawatch/forms.py
@@ -6,7 +6,8 @@ from .models import ManagementAction, Nest, Individual, NestPicture, IndividualP
 
 OBS_FORM_VUE_FIELDS = ({'field_name': 'observation_time', 'attribute_if_error': 'date_is_invalid'},
                        {'field_name': 'latitude', 'attribute_if_error': 'latitude_is_invalid'},
-                       {'field_name': 'longitude', 'attribute_if_error': 'longitude_is_invalid'}
+                       {'field_name': 'longitude', 'attribute_if_error': 'longitude_is_invalid'},
+                       {'field_name': 'address', 'attribute_if_error': 'address_is_invalid'}
                        )
 
 

--- a/vespawatch/templates/vespawatch/individual_create.html
+++ b/vespawatch/templates/vespawatch/individual_create.html
@@ -52,9 +52,13 @@
                 {% if form.data %}
                     v-bind:init-coordinates="[{{ form.data.longitude|default_if_none:'' }}, {{ form.data.latitude|default_if_none:'' }}]"
                     init-marker="true"
+                    :latitude-is-invalid={{ form.latitude_is_invalid|boolean_to_string }}
+                    :longitude-is-invalid={{ form.longitude_is_invalid|boolean_to_string }}
                 {% else %}
                     v-bind:init-coordinates="['', '']"
                     init-marker="false"
+                    :latitude-is-invalid={{ form.latitude_is_invalid|boolean_to_string }}
+                    :longitude-is-invalid={{ form.longitude_is_invalid|boolean_to_string }}
                 {% endif %}
                     address="{{ form.data.address|default_if_none:'' }}">
             </vw-location-selector>

--- a/vespawatch/templates/vespawatch/individual_create.html
+++ b/vespawatch/templates/vespawatch/individual_create.html
@@ -5,6 +5,10 @@
 {% load custom_tags %}
 
 {% block content %}
+    <script>
+        // set a global variable, accessible for JS
+        var formErrorMessagesRaw = "{{ form.errors_as_json }}";
+    </script>
 <main class="container" id="vw-main-app">
     <h1>{% trans 'Report observation' %}</h1>
 

--- a/vespawatch/templates/vespawatch/individual_create.html
+++ b/vespawatch/templates/vespawatch/individual_create.html
@@ -63,11 +63,13 @@
         <h5>{% trans 'Date' %}</h5>
         {% if object %}
             <vw-datetime-selector :is-required="true" hidden-field-name="observation_time"
-                init-date-time="{{ object.observation_time_iso }}">
+                init-date-time="{{ object.observation_time_iso }}"
+                :validation-error="true">
             </vw-datetime-selector>
         {% else %}
             <vw-datetime-selector :is-required="true" hidden-field-name="observation_time"
-                init-date-time="{{ form.data.observation_time|default_if_none:'' }}">
+                init-date-time="{{ form.data.observation_time|default_if_none:'' }}"
+                :validation-error={{ form.date_is_invalid|boolean_to_string }}>
             </vw-datetime-selector>
         {% endif %}
 

--- a/vespawatch/templates/vespawatch/individual_create.html
+++ b/vespawatch/templates/vespawatch/individual_create.html
@@ -42,27 +42,20 @@
         </div>
 
         <h5>{% trans 'Location' %}</h5>
-        {% if object %}
-            <vw-location-selector v-bind:init-coordinates="[{{ object.longitude }}, {{ object.latitude }}]"
+        <vw-location-selector
+            {% if form.data %}
+                v-bind:init-coordinates="[{{ form.data.longitude|default_if_none:'' }}, {{ form.data.latitude|default_if_none:'' }}]"
                 init-marker="true"
-                address="{{ object.address }}">
-            </vw-location-selector>
-        {% else %}
-            <vw-location-selector
-                {% if form.data %}
-                    v-bind:init-coordinates="[{{ form.data.longitude|default_if_none:'' }}, {{ form.data.latitude|default_if_none:'' }}]"
-                    init-marker="true"
-                    :latitude-is-invalid={{ form.latitude_is_invalid|boolean_to_string }}
-                    :longitude-is-invalid={{ form.longitude_is_invalid|boolean_to_string }}
-                {% else %}
-                    v-bind:init-coordinates="['', '']"
-                    init-marker="false"
-                    :latitude-is-invalid={{ form.latitude_is_invalid|boolean_to_string }}
-                    :longitude-is-invalid={{ form.longitude_is_invalid|boolean_to_string }}
-                {% endif %}
-                    address="{{ form.data.address|default_if_none:'' }}">
-            </vw-location-selector>
-        {% endif %}
+                :latitude-is-invalid={{ form.latitude_is_invalid|boolean_to_string }}
+                :longitude-is-invalid={{ form.longitude_is_invalid|boolean_to_string }}
+            {% else %}
+                v-bind:init-coordinates="['', '']"
+                init-marker="false"
+                :latitude-is-invalid={{ form.latitude_is_invalid|boolean_to_string }}
+                :longitude-is-invalid={{ form.longitude_is_invalid|boolean_to_string }}
+            {% endif %}
+                address="{{ form.data.address|default_if_none:'' }}">
+        </vw-location-selector>
 
         <h5>{% trans 'Date' %}</h5>
         {% if object %}

--- a/vespawatch/templates/vespawatch/nest_create.html
+++ b/vespawatch/templates/vespawatch/nest_create.html
@@ -52,16 +52,15 @@
             {% if form.data %}
                 v-bind:init-coordinates="[{{ form.data.longitude|default_if_none:'' }}, {{ form.data.latitude|default_if_none:'' }}]"
                 init-marker="true"
+                address="{{ form.data.address|default_if_none:'' }}"
+                :address-is-invalid={{ form.address_is_invalid|boolean_to_string }}
                 :latitude-is-invalid={{ form.latitude_is_invalid|boolean_to_string }}
                 :longitude-is-invalid={{ form.longitude_is_invalid|boolean_to_string }}
             {% else %}
                 v-bind:init-coordinates="['', '']"
                 init-marker="false"
             {% endif %}
-                address="{{ form.data.address|default_if_none:'' }}"
                 address-required="true">
-                :latitude-is-invalid={{ form.latitude_is_invalid|boolean_to_string }}
-                :longitude-is-invalid={{ form.longitude_is_invalid|boolean_to_string }}
         </vw-location-selector>
 
         <h5>{% trans 'Date' %}</h5>

--- a/vespawatch/templates/vespawatch/nest_create.html
+++ b/vespawatch/templates/vespawatch/nest_create.html
@@ -47,29 +47,22 @@
         </div>
 
         <h5>{% trans 'Location' %}</h5>
-        {% if object %}
-            <vw-location-selector v-bind:init-coordinates="[{{ object.longitude }}, {{ object.latitude }}]"
+
+        <vw-location-selector
+            {% if form.data %}
+                v-bind:init-coordinates="[{{ form.data.longitude|default_if_none:'' }}, {{ form.data.latitude|default_if_none:'' }}]"
                 init-marker="true"
-                address="{{ object.address }}"
+                :latitude-is-invalid={{ form.latitude_is_invalid|boolean_to_string }}
+                :longitude-is-invalid={{ form.longitude_is_invalid|boolean_to_string }}
+            {% else %}
+                v-bind:init-coordinates="['', '']"
+                init-marker="false"
+            {% endif %}
+                address="{{ form.data.address|default_if_none:'' }}"
                 address-required="true">
-            </vw-location-selector>
-        {% else %}
-            <vw-location-selector
-                {% if form.data %}
-                    v-bind:init-coordinates="[{{ form.data.longitude|default_if_none:'' }}, {{ form.data.latitude|default_if_none:'' }}]"
-                    init-marker="true"
-                    :latitude-is-invalid={{ form.latitude_is_invalid|boolean_to_string }}
-                    :longitude-is-invalid={{ form.longitude_is_invalid|boolean_to_string }}
-                {% else %}
-                    v-bind:init-coordinates="['', '']"
-                    init-marker="false"
-                {% endif %}
-                    address="{{ form.data.address|default_if_none:'' }}"
-                    address-required="true">
-                    :latitude-is-invalid={{ form.latitude_is_invalid|boolean_to_string }}
-                    :longitude-is-invalid={{ form.longitude_is_invalid|boolean_to_string }}
-            </vw-location-selector>
-        {% endif %}
+                :latitude-is-invalid={{ form.latitude_is_invalid|boolean_to_string }}
+                :longitude-is-invalid={{ form.longitude_is_invalid|boolean_to_string }}
+        </vw-location-selector>
 
         <h5>{% trans 'Date' %}</h5>
         {% if object %}

--- a/vespawatch/templates/vespawatch/nest_create.html
+++ b/vespawatch/templates/vespawatch/nest_create.html
@@ -5,6 +5,10 @@
 {% load custom_tags %}
 
 {% block content %}
+    <script>
+        // set a global variable, accessible for JS
+        var formErrorMessagesRaw = "{{ form.errors_as_json }}";
+    </script>
 <main class="container" id="vw-main-app">
     <h1>{% trans 'Report nest' %}</h1>
 

--- a/vespawatch/templates/vespawatch/nest_create.html
+++ b/vespawatch/templates/vespawatch/nest_create.html
@@ -58,12 +58,16 @@
                 {% if form.data %}
                     v-bind:init-coordinates="[{{ form.data.longitude|default_if_none:'' }}, {{ form.data.latitude|default_if_none:'' }}]"
                     init-marker="true"
+                    :latitude-is-invalid={{ form.latitude_is_invalid|boolean_to_string }}
+                    :longitude-is-invalid={{ form.longitude_is_invalid|boolean_to_string }}
                 {% else %}
                     v-bind:init-coordinates="['', '']"
                     init-marker="false"
                 {% endif %}
                     address="{{ form.data.address|default_if_none:'' }}"
                     address-required="true">
+                    :latitude-is-invalid={{ form.latitude_is_invalid|boolean_to_string }}
+                    :longitude-is-invalid={{ form.longitude_is_invalid|boolean_to_string }}
             </vw-location-selector>
         {% endif %}
 
@@ -74,7 +78,8 @@
             </vw-datetime-selector>
         {% else %}
             <vw-datetime-selector :is-required="true" hidden-field-name="observation_time"
-                init-date-time="{{ form.data.observation_time|default_if_none:'' }}">
+                init-date-time="{{ form.data.observation_time|default_if_none:'' }}"
+                :validation-error={{ form.date_is_invalid|boolean_to_string }}>
             </vw-datetime-selector>
         {% endif %}
 

--- a/vespawatch/templatetags/custom_tags.py
+++ b/vespawatch/templatetags/custom_tags.py
@@ -45,6 +45,14 @@ def js_config_object(context):
     }
     return mark_safe(json.dumps(conf))
 
+
 @register.filter
 def markdown(value, arg=None):
     return mark_safe(markdownify(value))
+
+
+@register.filter
+def boolean_to_string(value, arg=None):
+    if value is True:
+        return "true"
+    return "false"


### PR DESCRIPTION
There's now a basic mechanism in place that allows styling a Vue.js based field to report validation errors from a (Django) form.

It currently sets a red border when observation time, latitude or longitude is missing.

Don't hesitate to test, extend/improve and merge. 