### PR TITLE
Update to pyinaturalist 0.11

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -28,12 +28,12 @@ openpyxl==2.6.2
 pilkit==2.0
 Pillow==6.2.2
 psycopg2-binary==2.7.5
-pyinaturalist==0.8.0
+pyinaturalist==0.11.0
 python-dateutil==2.7.3
 pytz==2018.5
 PyYAML==5.1.1
 regex==2018.8.29
-requests==2.21.0
+requests==2.24.0
 six==1.11.0
 sqlparse==0.2.4
 tablib==0.13.0

--- a/vespawatch/management/commands/inaturalist_sync.py
+++ b/vespawatch/management/commands/inaturalist_sync.py
@@ -90,7 +90,7 @@ class Command(VespaWatchCommand):
         If we do have an observation with that iNaturalist ID, update it.
         """
         self.w("\n3. Pull all observations from iNaturalist (based on the project)")
-        observations = get_all_observations(params={'project_id': settings.VESPAWATCH_PROJECT_ID})
+        observations = get_all_observations(project_id=settings.VESPAWATCH_PROJECT_ID)
         pulled_inat_ids = []
         for inat_observation_data in observations:
             pulled_inat_ids.append(inat_observation_data['id'])


### PR DESCRIPTION
A new version of pyinaturalist has been released, so here are a few minor changes if you would like to use the latest version. This doesn't have much impact on the features that vespa-watch is using, except for some simplified usage for `create_observation()` and a few other functions. There is also a [dry-run mode](https://pyinaturalist.readthedocs.io/en/stable/general_usage.html#dry-run-mode) and some other features that you may find useful for testing & debugging. I also bumped `requests` to the latest version (2.24.0).